### PR TITLE
Add optional null to languge type

### DIFF
--- a/share.yaml
+++ b/share.yaml
@@ -194,7 +194,7 @@
             type: array
             items:
                 type: ["string", "null"]
-                pattern: "[a-z][a-z][a-z]"
+                pattern: "[a-z][a-z][a-z]?"
         licenses:
             description: The licenses under which the object has been released.
             type: "array"

--- a/share.yaml
+++ b/share.yaml
@@ -181,7 +181,7 @@
             properties:
                 startDate:
                     description: The date and time at which the object will be accessible. If the resource was always free to read, then the date the object was created should be used.
-                    type: "string"
+                    type: ["string", "null"]
                     format: date
                 endDate:
                     description: The date and time at which restrictions such as fees or registrations will be in place limiting accessibility.

--- a/share.yaml
+++ b/share.yaml
@@ -193,7 +193,7 @@
             description: The primary languages in which the content of the resource is presented. Values used for this element MUST conform to ISO 639–3. This offers two and three letter tags e.g. "en" or "eng" for English and "en-GB" for English used in the UK.
             type: array
             items:
-                type: string
+                type: ["string", "null"]
                 pattern: "[a-z][a-z][a-z]"
         licenses:
             description: The licenses under which the object has been released.


### PR DESCRIPTION
Many OAI PMH providers provide language, but not all. Adding the option for a string or null allows us to add it to the base OAI harvester without making the schema validator break for OAI providers that do not have language defined
